### PR TITLE
Pass through pointerEvents

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ class SafeView extends Component {
 
     return (
       <View
+        pointerEvents={this.props.pointerEvents}
         ref={c => (this.view = c)}
         onLayout={this._onLayout}
         style={[style, safeAreaStyle]}


### PR DESCRIPTION
Passes the pointerEvents attribute to the internal view. Previously this:

```jsx
<SafeAreaView pointerEvents="none">
 ...
</SafeAreaView>
```

did not respect the pointerEvents attribute