### PR TITLE
Default to pointerEvents='box-none'

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,11 @@ class SafeView extends Component {
     const { forceInset = false, isLandscape, children, style } = this.props;
 
     if (Platform.OS !== 'ios') {
-      return <View style={style}>{this.props.children}</View>;
+      return (
+        <View style={style} pointerEvents='box-none'>
+          {this.props.children}
+        </View>
+      );
     }
 
     const safeAreaStyle = this._getSafeAreaStyle();
@@ -111,6 +115,7 @@ class SafeView extends Component {
         ref={c => (this.view = c)}
         onLayout={this._onLayout}
         style={safeAreaStyle}
+        pointerEvents='box-none'
       >
         {this.props.children}
       </View>


### PR DESCRIPTION
Prevents the SafeAreaView from blocking touches. Rather than passing through the prop this PR just sets it to 'box-none' which causes touches to pass through SafeAreaView but allows its children to receive them. If someone wanted to receive touches one the entire component inside the view they could wire them up to the top level child.