### PR TITLE
make forceInset works in all iphone

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ class SafeView extends Component {
       paddingRight: touchesRight ? this._getInset('right') : 0,
     };
 
-    if (isIPhoneX && forceInset) {
+    if (forceInset) {
       Object.keys(forceInset).forEach(key => {
         let inset = forceInset[key];
 


### PR DESCRIPTION
I use `forceInset` like `{ top: 'never' }` to disable paddingTop.
But it seems like `forceInset` only work while it is in iphone x.
This doesn't make sense because I think the `forceInset` is setted global, otherwise it will bring ambiguity.

Hope this can be merge & new version can be release ASAP. 