### PR TITLE
Implement a dummy DeviceInfo component for react-native-web usage.

### DIFF
--- a/PlatformHelper.js
+++ b/PlatformHelper.js
@@ -1,19 +1,7 @@
 import {
   DeviceInfo,
-  Dimensions,
-  InteractionManager,
-  NativeModules,
-  Platform,
-  StyleSheet,
-  Animated,
 } from 'react-native';
 
 export {
   DeviceInfo,
-  Dimensions,
-  InteractionManager,
-  NativeModules,
-  Platform,
-  StyleSheet,
-  Animated,
 }

--- a/PlatformHelper.js
+++ b/PlatformHelper.js
@@ -1,0 +1,19 @@
+import {
+  DeviceInfo,
+  Dimensions,
+  InteractionManager,
+  NativeModules,
+  Platform,
+  StyleSheet,
+  Animated,
+} from 'react-native';
+
+export {
+  DeviceInfo,
+  Dimensions,
+  InteractionManager,
+  NativeModules,
+  Platform,
+  StyleSheet,
+  Animated,
+}

--- a/PlatformHelper.web.js
+++ b/PlatformHelper.web.js
@@ -1,23 +1,8 @@
-import {
-  Dimensions,
-  InteractionManager,
-  NativeModules,
-  Platform,
-  StyleSheet,
-  Animated,
-} from 'react-native';
-
 const DeviceInfo = {
   isIPhoneX_deprecated: false
 };
 
 export {
   DeviceInfo,
-  Dimensions,
-  InteractionManager,
-  NativeModules,
-  Platform,
-  StyleSheet,
-  Animated,
 }
 

--- a/PlatformHelper.web.js
+++ b/PlatformHelper.web.js
@@ -1,0 +1,23 @@
+import {
+  Dimensions,
+  InteractionManager,
+  NativeModules,
+  Platform,
+  StyleSheet,
+  Animated,
+} from 'react-native';
+
+const DeviceInfo = {
+  isIPhoneX_deprecated: false
+};
+
+export {
+  DeviceInfo,
+  Dimensions,
+  InteractionManager,
+  NativeModules,
+  Platform,
+  StyleSheet,
+  Animated,
+}
+

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import {
   Platform,
   StyleSheet,
   Animated,
-} from 'react-native';
+} from './PlatformHelper';
 import withOrientation from './withOrientation';
 
 // See https://mydevice.io/devices/ for device dimensions

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import {
-  DeviceInfo,
   Dimensions,
   InteractionManager,
   NativeModules,
   Platform,
   StyleSheet,
   Animated,
-} from './PlatformHelper';
+} from './react-native';
+import { DeviceInfo } from './PlatformHelper';
 import withOrientation from './withOrientation';
 
 // See https://mydevice.io/devices/ for device dimensions


### PR DESCRIPTION
When using this package under react-native-web, the DeviceInfo component is not found, because it's not implemented by react-native-web. Instead, under web, supply our own dummy.