### PR TITLE
Fix web usage

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export default ({ children, style }) => <View style={style}>{children}</View>;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-safe-area-view",
   "version": "0.6.0",
   "description": "JS only version of SafeAreaView for supporting iPhone X safe area insets.",
-  "main": "index.js",
+  "main": "index",
   "scripts": {
     "test": "test"
   },


### PR DESCRIPTION
Hello,

Correct me if I'm wrong: I don't see any usage for this library inside a browser.
Nevertheless, some libraries use this package without knowing that they're being used on the web; and this has side effects.

For example, this header with `react-navigation`:
![image](https://user-images.githubusercontent.com/82368/36178280-9dd10e9c-1118-11e8-95cb-c0ecacebb0ab.png)

This PR makes this package transparent for the web. :)