### PR TITLE
Expose static getInset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ Sometimes you will observe unexpected behavior and jank because SafeAreaView use
 
 ## methods
 
-### getInset
+### getInset(key, isLandscape)
 
 If you need to access inset information, use the SafeAreaView's static `getInset` method.
 Accepts 2 parameters:
-`key`: `top | right | bottom | left` The inset to get
-`isLandscape`: `true | false` Whether the app is currently in landscape position. Default = false
+#### key
+`top | right | bottom | left` 
+
+The inset direction to get
+#### isLandscape
+`true | false`
+
+Whether the app is currently in landscape position. Default = false
 Example:
 ```javascript
   <NavigationHeader style={{paddingTop: SafeAreaView.getInset('top')}} />

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Sometimes you will observe unexpected behavior and jank because SafeAreaView use
 ```
 
 `forceInset` takes an object with the keys `top | bottom | left | right | vertical | horizontal` and the values `'always' | 'never'`. Or you can override the padding altogether by passing an integer.
+
+## methods
+
+### getInset
+
+If you need to access inset information, use the SafeAreaView's static `getInset` method.
+Accepts 2 parameters:
+`key`: `top | right | bottom | left` The inset to get
+`isLandscape`: `true | false` Whether the app is currently in landscape position. Default = false
+Example:
+```javascript
+  <NavigationHeader style={{paddingTop: SafeAreaView.getInset('top')}} />
+```

--- a/index.js
+++ b/index.js
@@ -196,10 +196,10 @@ class SafeView extends Component {
 
     const style = {
       ...viewStyle,
-      paddingTop: touchesTop ? this.getInset('top', isLandscape) : 0,
-      paddingBottom: touchesBottom ? this.getInset('bottom', isLandscape) : 0,
-      paddingLeft: touchesLeft ? this.getInset('left', isLandscape) : 0,
-      paddingRight: touchesRight ? this.getInset('right', isLandscape) : 0,
+      paddingTop: touchesTop ? SafeView.getInset('top', isLandscape) : 0,
+      paddingBottom: touchesBottom ? SafeView.getInset('bottom', isLandscape) : 0,
+      paddingLeft: touchesLeft ? SafeView.getInset('left', isLandscape) : 0,
+      paddingRight: touchesRight ? SafeView.getInset('right', isLandscape) : 0,
     };
 
     if (forceInset) {
@@ -207,7 +207,7 @@ class SafeView extends Component {
         let inset = forceInset[key];
 
         if (inset === 'always') {
-          inset = this.getInset(key, isLandscape);
+          inset = SafeView.getInset(key, isLandscape);
         }
 
         if (inset === 'never') {

--- a/index.js
+++ b/index.js
@@ -196,10 +196,10 @@ class SafeView extends Component {
 
     const style = {
       ...viewStyle,
-      paddingTop: touchesTop ? this._getInset('top') : 0,
-      paddingBottom: touchesBottom ? this._getInset('bottom') : 0,
-      paddingLeft: touchesLeft ? this._getInset('left') : 0,
-      paddingRight: touchesRight ? this._getInset('right') : 0,
+      paddingTop: touchesTop ? this.getInset('top', isLandscape) : 0,
+      paddingBottom: touchesBottom ? this.getInset('bottom', isLandscape) : 0,
+      paddingLeft: touchesLeft ? this.getInset('left', isLandscape) : 0,
+      paddingRight: touchesRight ? this.getInset('right', isLandscape) : 0,
     };
 
     if (forceInset) {
@@ -207,7 +207,7 @@ class SafeView extends Component {
         let inset = forceInset[key];
 
         if (inset === 'always') {
-          inset = this._getInset(key);
+          inset = this.getInset(key, isLandscape);
         }
 
         if (inset === 'never') {
@@ -295,8 +295,7 @@ class SafeView extends Component {
     };
   };
 
-  _getInset = key => {
-    const { isLandscape } = this.props;
+  static getInset = (key, isLandscape = false) => {
     switch (key) {
       case 'horizontal':
       case 'right':


### PR DESCRIPTION
This changes the getInset method to static, allowing use in custom UI components, etc...
solves https://github.com/react-community/react-native-safe-area-view/issues/22