### PR TITLE
Don't call setState on unmounted component in measureInWindow

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,9 @@ class SafeView extends Component {
     const HEIGHT = isLandscape ? X_WIDTH : X_HEIGHT;
 
     this.view._component.measureInWindow((winX, winY, winWidth, winHeight) => {
+      if (!this.view) {
+        return;
+      }
       let realY = winY;
       let realX = winX;
 


### PR DESCRIPTION
Fixes issue #28 and `react-navigation` issue [#3992](https://github.com/react-navigation/react-navigation/issues/3992)