### PR TITLE
setStatusBarHeight should trigger re-render

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,24 @@ const doubleFromPercentString = percent => {
   return dbl;
 };
 
+const MountedInstances = (() => {
+  let mountedInstances = [];
+  const add = instance => mountedInstances = [...mountedInstances,instance];
+  const remove = instance => mountedInstances = mountedInstances.filter(mountedInstance => mountedInstance !== instance);
+  const forceUpdate = () => mountedInstances.forEach(instance => instance.forceUpdate());
+  return {
+    add,
+    remove,
+    render,
+  };
+})();
+
 class SafeView extends Component {
-  static setStatusBarHeight = height => {
+  static setStatusBarHeight = (height, forceUpdate = true) => {
     _customStatusBarHeight = height;
+    if (forceUpdate) {
+      MountedInstances.forceUpdate();
+    }
   };
 
   state = {
@@ -112,6 +127,7 @@ class SafeView extends Component {
   };
 
   componentDidMount() {
+    MountedInstances.add(this);
     InteractionManager.runAfterInteractions(() => {
       this._onLayout();
     });
@@ -119,6 +135,10 @@ class SafeView extends Component {
 
   componentWillReceiveProps() {
     this._onLayout();
+  }
+
+  componentWillUnmount() {
+    MountedInstances.remove(this);
   }
 
   render() {


### PR DESCRIPTION
Hi,

On iOS the statusbar height might change (when calling someone, or when sharing network connection)

The following package permit to listen for such changes: https://github.com/expo/status-bar-height
See also https://blog.expo.io/the-status-bar-manager-in-react-native-6226058ecba

If the height change during the lifetime of the app, we should rather make the safeArea views re-render so that the view does not appear under the statusbar extra height. 


The idea is that I could write the following integration code to track correctly the statusbar:

```js
export const trackStatusBarHeightChanges = async () => {
  const initialHeight = await StatusBarHeight.getAsync();
  SafeAreaView.setStatusBarHeight(initialHeight);
  const listener = height => SafeAreaView.setStatusBarHeight(height);
  StatusBarHeight.addEventListener(listener);
  return () => StatusBarHeight.removeEventListener(listener);
};
```
