### PR TITLE
Fix the deprecated is mounted

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,19 @@
-import { ComponentClass } from 'react'
-import { ViewProperties } from 'react-native'
+import { ComponentClass } from 'react';
+import { ViewProperties } from 'react-native';
 
-export type SafeAreaViewForceInsetValue = 'always' | 'never'
+export type SafeAreaViewForceInsetValue = 'always' | 'never';
 
 export interface SafeAreaViewProps extends ViewProperties {
   forceInset?: {
-    top?: SafeAreaViewForceInsetValue
-    bottom?: SafeAreaViewForceInsetValue
-    left?: SafeAreaViewForceInsetValue
-    right?: SafeAreaViewForceInsetValue
-    horizontal?: SafeAreaViewForceInsetValue
-    vertical?: SafeAreaViewForceInsetValue
-  }
+    top?: SafeAreaViewForceInsetValue;
+    bottom?: SafeAreaViewForceInsetValue;
+    left?: SafeAreaViewForceInsetValue;
+    right?: SafeAreaViewForceInsetValue;
+    horizontal?: SafeAreaViewForceInsetValue;
+    vertical?: SafeAreaViewForceInsetValue;
+  };
 }
 
-export const SafeAreaView: ComponentClass<SafeAreaViewProps>
+export const SafeAreaView: ComponentClass<SafeAreaViewProps>;
 
-export default SafeAreaView
+export default SafeAreaView;

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ class SafeView extends Component {
     return (
       <Animated.View
         ref={c => (this.view = c)}
-        pointerEvents='box-none'
+        pointerEvents="box-none"
         {...props}
         onLayout={this._onLayout}
         style={safeAreaStyle}
@@ -160,13 +160,13 @@ class SafeView extends Component {
       if (realY >= HEIGHT) {
         realY = realY % HEIGHT;
       } else if (realY < 0) {
-        realY = realY % HEIGHT + HEIGHT;
+        realY = (realY % HEIGHT) + HEIGHT;
       }
 
       if (realX >= WIDTH) {
         realX = realX % WIDTH;
       } else if (realX < 0) {
-        realX = realX % WIDTH + WIDTH;
+        realX = (realX % WIDTH) + WIDTH;
       }
 
       const touchesTop = realY === 0;
@@ -183,7 +183,7 @@ class SafeView extends Component {
         viewWidth: winWidth,
         viewHeight: winHeight,
       });
-      
+
       if (this.props.onLayout) this.props.onLayout(...args);
     });
   };

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ class SafeView extends Component {
   };
 
   componentDidMount() {
+    this.view._component.__isMounted = true;
     InteractionManager.runAfterInteractions(() => {
       this._onLayout();
     });
@@ -119,6 +120,10 @@ class SafeView extends Component {
 
   componentWillReceiveProps() {
     this._onLayout();
+  }
+
+  componentWillUnmount() {
+    this.view._component.__isMounted = false;
   }
 
   render() {

--- a/withOrientation.js
+++ b/withOrientation.js
@@ -41,7 +41,7 @@ export default function<T: {}>(
 
     componentWillUnmount() {
       if (typeof Dimensions.removeEventListener === 'function') {
-        Dimensions.removeEventListener('change', this.handleOrientationChange);  
+        Dimensions.removeEventListener('change', this.handleOrientationChange);
       }
     }
 

--- a/withSafeArea.js
+++ b/withSafeArea.js
@@ -3,8 +3,8 @@ import hoistStatics from 'hoist-non-react-statics';
 
 import SafeAreaView from './';
 
-export default function (forceInset = {}) {
-  return (WrappedComponent) => {
+export default function(forceInset = {}) {
+  return WrappedComponent => {
     class withSafeArea extends Component {
       render() {
         return (


### PR DESCRIPTION
# Problem

On my actual RN project (0.56), we used to see some warning like this:

![image](https://user-images.githubusercontent.com/13785185/44213214-7585a480-a16d-11e8-93c6-7e9fa5d8adaa.png)

You can read more details about the actual root cause here: https://github.com/facebook/react-native/issues/18868 but long story short, in react renderer, there is a function that does:

```js
/**
 * In the future, we should cleanup callbacks by cancelling them instead of
 * using this.
 */
function mountSafeCallback(context, callback) {
  return function() {
    if (!callback) {
      return undefined;
    }
    if (typeof context.__isMounted === "boolean") {
      // TODO(gaearon): this is gross and should be removed.
      // It is currently necessary because View uses createClass,
      // and so any measure() calls on View (which are done by React
      // DevTools) trigger the isMounted() deprecation warning.
      if (!context.__isMounted) {
        return undefined;
      }
      // The else branch is important so that we don't
      // trigger the deprecation warning by calling isMounted.
    } else if (typeof context.isMounted === "function") {
      if (!context.isMounted()) {
        return undefined;
      }
    }
    return callback.apply(context, arguments);
  };
}
```

`context.isMounted()` is thus call on `mountSafeCallback()` which is call  internally by `this.view._component.measureInWindow()` on line 158.

The error use not to be seen because `<View />` use to be a `React.createClass` until recently and `React.createClass` was setting the `isMounted` properties throught a mixin (AFAIK).

# Proposition

![image](https://user-images.githubusercontent.com/13785185/44215053-dadb9480-a171-11e8-9cac-db0067e9d28c.png).

But, it may be hacky...

Need @gaearon prophecy on this to know if the pattern is actually recommended by the react/react-native team as the comment in react codebase (`TODO(gaearon): this is gross and should be removed.`) is troubling 😱.

# Alternatives

RN users can use yellow box api like this to mask (as per https://github.com/facebook/react-native/issues/18868#issuecomment-390207572)

```js
import { YellowBox } from 'react-native'
YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated'])
````

but this solution require an good understanding of RN code. Most users will just RN as broken.
Moreover this don't works for expo guys (cc @brentvatne).

Expo users must do something nastier (as per https://github.com/facebook/react-native/issues/18868#issuecomment-390369568)

```js 
global.__old_console_warn = global.__old_console_warn || console.warn;
global.console.warn = str => {
  let tst = (str || '') + '';
  if (tst.startsWith('Warning: isMounted(...) is deprecated')) {
    return;
  }
  return global.__old_console_warn.apply(console, [str]);
};
```

I will thus recommend to merge this and upgrade the deps in https://github.com/react-navigation/react-navigation as this is simple and can only improve the user experience : if RN fix this, the hack will become useless, if react change the 

```js
  // ...
  if (typeof context.__isMounted === "boolean") {
      // TODO(gaearon): this is gross and should be removed.
      // It is currently necessary because View uses createClass,
      // and so any measure() calls on View (which are done by React
      // DevTools) trigger the isMounted() deprecation warning.
      if (!context.__isMounted) {
        return undefined;
      }
      // The else branch is important so that we don't
      // trigger the deprecation warning by calling isMounted.
    }  else {

  }
```

the warning will just reappear.

# Note

Credits to @rchanaud, we did the investigation together.

I did profit from this PR to prettify the code using prettier.
This is a separate commit and I selected a config that match the actual code style.

If you request changes and I don't answer, feel free to edit the needed changes.