### PR TITLE
Added support for new iPad Pro safe area insets

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ const XSMAX_WIDTH = 414;
 const XSMAX_HEIGHT = 896;
 const PAD_WIDTH = 768;
 const PAD_HEIGHT = 1024;
+const IPADPRO11_WIDTH = 834;
+const IPADPRO11_HEIGHT = 1194;
+const IPADPRO129_HEIGHT = 1024;
+const IPADPRO129_WIDTH = 1366;
 
 const { height: D_HEIGHT, width: D_WIDTH } = Dimensions.get('window');
 
@@ -33,6 +37,18 @@ const isIPhoneX = (() => {
       (D_HEIGHT === X_WIDTH && D_WIDTH === X_HEIGHT)) ||
     ((D_HEIGHT === XSMAX_HEIGHT && D_WIDTH === XSMAX_WIDTH) ||
         (D_HEIGHT === XSMAX_WIDTH && D_WIDTH === XSMAX_HEIGHT))
+  );
+})();
+
+const isNewIPadPro = (() => {
+  if (Platform.OS === 'web') return false;
+
+  return (
+    Platform.OS === 'ios' &&
+    ((D_HEIGHT === IPADPRO11_HEIGHT && D_WIDTH === IPADPRO11_WIDTH) ||
+      (D_HEIGHT === IPADPRO11_WIDTH && D_WIDTH === IPADPRO11_HEIGHT)) ||
+    ((D_HEIGHT === IPADPRO129_HEIGHT && D_WIDTH === IPADPRO129_WIDTH) ||
+        (D_HEIGHT === IPADPRO129_WIDTH && D_WIDTH === IPADPRO129_HEIGHT))
   );
 })();
 
@@ -74,6 +90,10 @@ const statusBarHeight = isLandscape => {
 
   if (isIPhoneX) {
     return isLandscape ? 0 : 44;
+  }
+
+  if (isNewIPadPro) {
+    return 24;
   }
 
   if (isIPad) {
@@ -319,7 +339,15 @@ class SafeView extends Component {
         return statusBarHeight(isLandscape);
       }
       case 'bottom': {
-        return isIPhoneX ? (isLandscape ? 24 : 34) : 0;
+        if (isIPhoneX) {
+          return isLandscape ? 24 : 34;
+        }
+
+        if (isNewIPadPro) {
+          return 20;
+        }
+
+        return 0;
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -43,13 +43,10 @@ const isIPhoneX = (() => {
 const isNewIPadPro = (() => {
   if (Platform.OS !== 'ios') return false;
 
-  return (
-    Platform.OS === 'ios' &&
-    ((D_HEIGHT === IPADPRO11_HEIGHT && D_WIDTH === IPADPRO11_WIDTH) ||
+  return ((D_HEIGHT === IPADPRO11_HEIGHT && D_WIDTH === IPADPRO11_WIDTH) ||
       (D_HEIGHT === IPADPRO11_WIDTH && D_WIDTH === IPADPRO11_HEIGHT)) ||
     ((D_HEIGHT === IPADPRO129_HEIGHT && D_WIDTH === IPADPRO129_WIDTH) ||
-        (D_HEIGHT === IPADPRO129_WIDTH && D_WIDTH === IPADPRO129_HEIGHT))
-  );
+        (D_HEIGHT === IPADPRO129_WIDTH && D_WIDTH === IPADPRO129_HEIGHT));
 })();
 
 const isIPad = (() => {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const isIPhoneX = (() => {
 })();
 
 const isNewIPadPro = (() => {
-  if (Platform.OS === 'web') return false;
+  if (Platform.OS !== 'ios') return false;
 
   return (
     Platform.OS === 'ios' &&


### PR DESCRIPTION
Added support for new iPad Pro models, 11-inch and 12.9 inch (3rd generation).
Please checkup the new variables names.

See https://github.com/react-native-community/react-native-safe-area-view/issues/54
