### PR TITLE
[iOS] Hidden status bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ const isIPad = (() => {
 })();
 
 let _customStatusBarHeight = null;
+let _customStatusBarHidden = null;
 const statusBarHeight = isLandscape => {
   if (_customStatusBarHeight !== null) {
     return _customStatusBarHeight;
@@ -96,10 +97,10 @@ const statusBarHeight = isLandscape => {
   }
 
   if (isIPad) {
-    return 20;
+    return _customStatusBarHidden ? 0 : 20;
   }
 
-  return isLandscape ? 0 : 20;
+  return (isLandscape || _customStatusBarHidden) ? 0 : 20;
 };
 
 const doubleFromPercentString = percent => {
@@ -117,6 +118,10 @@ const doubleFromPercentString = percent => {
 class SafeView extends Component {
   static setStatusBarHeight = height => {
     _customStatusBarHeight = height;
+  };
+
+  static setStatusBarHidden = hidden => {
+    _customStatusBarHidden = hidden;
   };
 
   state = {


### PR DESCRIPTION
Add a way to specify if the status bar is hidden, then respect that setting on devices that do not have safe areas related to physical screen features, such as notch or rounded corners.

For instance, iPhone X should always have a safe area around the notch, even if status bar is hidden, but normal phones should not.

See #62 