### PR TITLE
Add 'withSafeArea` to TS Definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,4 +16,6 @@ export interface SafeAreaViewProps extends ViewProperties {
 
 export const SafeAreaView: ComponentClass<SafeAreaViewProps>
 
+export const withSafeArea: <P extends object>(safeAreaViewProps?: SafeAreaViewProps) => (Component: React.ComponentType<P>) => ComponentClass<P & SafeAreaViewProps>
+
 export default SafeAreaView

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,6 @@ export interface SafeAreaViewProps extends ViewProperties {
 
 export const SafeAreaView: ComponentClass<SafeAreaViewProps>
 
-export const withSafeArea: <P extends object>(safeAreaViewProps?: SafeAreaViewProps) => (Component: React.ComponentType<P>) => ComponentClass<P & SafeAreaViewProps>
+export const withSafeArea: <P extends object>(safeAreaViewProps?: SafeAreaViewProps) => (Component: React.ComponentType<P>) => React.ComponentType<P & SafeAreaViewProps>
 
 export default SafeAreaView


### PR DESCRIPTION
Noticed that the TS definition doesn't include the `withSafeArea` HOC