### PR TITLE
do not access private animated api

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ class SafeView extends Component {
 
     const { width: WIDTH, height: HEIGHT } = getResolvedDimensions();
 
-    this.view._component.measureInWindow((winX, winY, winWidth, winHeight) => {
+    this.view.getNode().measureInWindow((winX, winY, winWidth, winHeight) => {
       if (!this.view) {
         return;
       }


### PR DESCRIPTION
the code access `_component` which was meant to stay private, but there is a public accessor to that information that should be used instead: https://github.com/facebook/react-native/blob/b241bc2d0ba41ff91408568950f0863020d4f3a6/Libraries/Animated/src/createAnimatedComponent.js#L173