### PR TITLE
Add `getInset` to the Flow types

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -22,3 +22,8 @@ export default class SafeAreaView extends React$Component<SafeAreaViewProps> {}
 declare export function withSafeArea(
   forceInset?: ?ForceInset
 ): <T: React$ComponentType<*>>(WrappedComponent: T) => T;
+
+declare export function getInset(
+  value: 'horizontal' | 'right' | 'left' | 'vertical' | 'top' | 'bottom',
+  isLandscape: boolean
+): number


### PR DESCRIPTION
# Summary

The `getInset` function is documented in the readme, but Flow complains because it isn't in the types. Whoever added the method must have forgotten to update the types.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I am using this branch locally in my project with no Flow errors. Without it, Flow complains about `getInset` being missing.

### What's required for testing (prerequisites)?

See bug #74

### What are the steps to reproduce (after prerequisites)?

See bug #74

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

Um, there is no `CHANGELOG.md`!