### PR TITLE
added setStatusBarHeight and setStatusBarHidden on typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,10 @@ export interface SafeAreaViewProps extends ViewProperties {
 
 export const getStatusBarHeight: (isLandscape?: boolean) => number;
 
+export const setStatusBarHeight: (height: number) => void;
+
+export const setStatusBarHidden: (hidden: boolean) => void;
+
 export const getInset: (
   key: 'top' | 'right' | 'bottom' | 'left',
   isLandscape?: boolean


### PR DESCRIPTION
this PR will fix the compile error when try to use 

`setStatusBarHeight`
`setStatusBarHidden`

https://github.com/react-native-community/react-native-safe-area-view/blob/master/index.js#L125-L131