### PR TITLE
Use `Platform.constants` instead of `NativeModules.PlatformConstants`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import {
   Dimensions,
   InteractionManager,
-  NativeModules,
   Platform,
   StyleSheet,
   Animated,
@@ -31,7 +30,7 @@ const getResolvedDimensions = () => {
 
 const { height: D_HEIGHT, width: D_WIDTH } = getResolvedDimensions();
 
-const { PlatformConstants = {} } = NativeModules;
+const PlatformConstants = Platform.constants || {};
 const { minor = 0 } = PlatformConstants.reactNativeVersion || {};
 
 const isIPhoneX = (() => {


### PR DESCRIPTION
# Summary

With TurboModules `NativeModules.PlatformConstants` does not exist anymore. Constants are exported on the `Platform` module anyway so it's a better way to use it.

The code tried to be safe and use default values but NativeModules returns `null` and not `undefined` when a module does not exists so it doesn't work.

## Test Plan

Reproduced the crash in an app and made sure this fixes it.

### What's required for testing (prerequisites)?

RN master on iOS

### What are the steps to reproduce (after prerequisites)?

Simply run an app that uses this module, crashes on start.

## Compatibility

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
