### PR TITLE
Safe area context 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2020-05-11
+
+### ⚠ BREAKING CHANGES
+
+* `SafeAreaContext` was renamed to `SafeAreaInsetsContext`, corresponding to `react-native-safe-area-context` v1.0.
+
+`useSafeArea` and `SafeAreaConsumer` have been deprecated, but are still available at this time.
+See https://github.com/th3rdwave/react-native-safe-area-context/releases/tag/1.0.0
+
+### Added
+
+* Support for `react-native-safe-area-context` 1.0
+
 ## [1.1.0]
 
 ## Added

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "react-native": "~0.61.5",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.7.0",
-    "react-native-safe-area-context": "0.7.3",
+    "react-native-safe-area-context": "^1.0.0",
     "react-native-safe-area-view": "^0.14.7",
     "react-native-screens": "~2.2.0",
     "react-native-unimodules": "~0.9.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6438,10 +6438,10 @@ react-native-reanimated@~1.7.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
-  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
+react-native-safe-area-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-1.0.0.tgz#8b4d79b06d6a9ed5ff3b2c3f0ba25d85538a3149"
+  integrity sha512-8Poo0FHSS/KE0fP6JUH9Mnjg2KQ5MfZAJN3G8/gW2HoFSypWSfFmDp5msETU0Ix3OnRsmBZTJpmgHFEl9OfNAg==
 
 react-native-safe-area-view@^0.14.7:
   version "0.14.9"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-safe-area-view",
   "description": "Add padding to your views to account for notches, home indicators, status bar, and possibly other future things.",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "author": "Dave Pack (dpack3.0@gmail.com), Brent Vatne (brent@expo.io)",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-safe-area-context": "*"
+    "react-native-safe-area-context": ">=1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7",
@@ -59,7 +59,7 @@
     "prettier": "^1.18.2",
     "react": "16.8.3",
     "react-native": "~0.61.4",
-    "react-native-safe-area-context": "0.7.3",
+    "react-native-safe-area-context": "^1.0.0",
     "typescript": "^3.8.3"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,16 +11,24 @@ import {
 } from 'react-native';
 import {
   EdgeInsets,
-  SafeAreaContext,
-  SafeAreaProvider,
   SafeAreaConsumer,
+  SafeAreaInsetsContext,
+  SafeAreaProvider,
   useSafeArea,
+  useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 
 import shallowEquals from './shallowEquals';
 
 // Re-export react-native-safe-area-context utilities
-export { useSafeArea, SafeAreaProvider, SafeAreaConsumer, SafeAreaContext };
+export {
+  useSafeAreaInsets,
+  SafeAreaProvider,
+  SafeAreaInsetsContext,
+  // Deprecated:
+  useSafeArea,
+  SafeAreaConsumer,
+};
 
 export type ForceInsetValue = 'always' | 'never';
 export type ForceInsetProp = {
@@ -53,8 +61,8 @@ interface AnimatedView extends Animated.AnimatedComponent<View> {
 }
 
 export default class SafeAreaView extends React.Component<Props, State> {
-  static contextType: any = SafeAreaContext;
-  context!: React.ContextType<typeof SafeAreaContext>;
+  static contextType: any = SafeAreaInsetsContext;
+  context!: React.ContextType<typeof SafeAreaInsetsContext>;
   private _isMounted: boolean = false;
   private _view = React.createRef<AnimatedView>();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,10 +3934,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-native-safe-area-context@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
-  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
+react-native-safe-area-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-1.0.0.tgz#8b4d79b06d6a9ed5ff3b2c3f0ba25d85538a3149"
+  integrity sha512-8Poo0FHSS/KE0fP6JUH9Mnjg2KQ5MfZAJN3G8/gW2HoFSypWSfFmDp5msETU0Ix3OnRsmBZTJpmgHFEl9OfNAg==
 
 react-native@~0.61.4:
   version "0.61.5"


### PR DESCRIPTION
# Summary

Hello, thanks for this super handy library!

[react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) just hit Semver compatibility with a [1.0 release](https://github.com/th3rdwave/react-native-safe-area-context/releases/tag/1.0.0). :tada:

It introduces one breaking change (renaming `SafeAreaContext` to `SafeAreaInsetsContext`) and a few deprecations.

Users who currently run the installation instructions in the README will have a broken installation: safe-area-context@1.0 will be installed and linked in their app, which conflicts with the hard-versioned `0.7.3` depended on by this library.

In order to update the changelog with the breaking changes (as instructed in the PR template), I performed a major version bump. Can definitely revert that if it's more appropriate for maintainers to handle all versioning.

Also, since the "breaking change" is only a re-export (and probably a lesser-used one as well, since users probably import directly from safe-area-context), you may not want to perform a full major version bump.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

I will be testing more thoroughly soon, but I took a brief detour to get Github Actions up and running for this repo first (another PR incoming shortly)

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- ~~[ ] I added the documentation in `README.md`~~ n/a
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- ~~[ ] I added a sample use of the API in the example project (`example/App.js`)~~ no change to example

Thanks for your time!