### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn test
+  android-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-example-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-example-
+      - name: Install dependencies
+        run: cd example/android && yarn install
+      - name: Build android example app
+        run: cd example/android && ./gradlew assembleDebug
+  ios-build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.x'
+      - name: Install cocoapods
+        run: gem install cocoapods
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-example-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-example-
+      - name: Install dependencies
+        run: cd example/ios && yarn install
+      - name: Install pods
+        run: cd example/ios && pod install
+      - name: Build ios example app
+        run: cd example/ios && xcodebuild -scheme SafeAreaViewExample -workspace SafeAreaViewExample.xcworkspace ONLY_ACTIVE_ARCH=NO -sdk iphonesimulator -configuration Debug

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -145,14 +145,6 @@ android {
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
-    signingConfigs {
-        debug {
-            storeFile file('debug.keystore')
-            storePassword 'android'
-            keyAlias 'androiddebugkey'
-            keyPassword 'android'
-        }
-    }
     buildTypes {
         debug {
             signingConfig signingConfigs.debug

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
     "singleQuote": true
   },
   "scripts": {
-    "test": "jest",
+    "test": "yarn validate:prettier && yarn typescript",
     "typescript": "tsc --noEmit",
+    "validate:prettier": "npx prettier \"src/**/*.{js,ts,tsx}\" \"example/**/*.{js,ts,tsx}\" --check",
     "prepare": "bob build",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Hello again -

While preparing PR #119, I saw that this repo does not have any CI build set up, so that's what this PR is for.

The `test` script in `package.json` has been replaced with a `prettier` + TypeScript check. The previous `jest` run was not passing (and the only tests are blank/boilerplate files in the example folder).

The github action template was taken almost directly from https://github.com/th3rdwave/react-native-safe-area-context 

It:
* Runs `yarn test` (currently prettier and TypeScript checks)
* Builds android example app
* Builds iOS example app

The action can be seen in-action here on my fork: https://github.com/davidgovea/react-native-safe-area-view/actions/runs/101144121 (I don't believe they will run on this repo for a 3rd-party fork)

safe-area-context also has some good patterns for eslint, and test files. I'd be happy to help further, but I figured small, incremental PRs are easier to discuss.

Thanks for your time!