### PR TITLE
docs: fixes import mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default function App() {
 Now you can wrap components that touch any edge of the screen with a `SafeAreaView`.
 
 ```jsx
-import { SafeAreaView } from 'react-native-safe-area-view';
+import SafeAreaView from 'react-native-safe-area-view';
 
 export default function MyAwesomeApp() {
   return (


### PR DESCRIPTION
SafeAreaView is exported as default Class , but in example in README it is imported in wrong way like 
```
import {SafeAreView} from 'react-native-safe-area-view'
```
instead of 
```
import SafeAreView from 'react-native-safe-area-view'
```