### PR TITLE
fix(readme): update readme to correct export

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default function App() {
 Now you can wrap components that touch any edge of the screen with a `SafeAreaView`.
 
 ```jsx
-import { SafeAreaView } from 'react-native-safe-area-view';
+import SafeAreaView from 'react-native-safe-area-view';
 
 export default function MyAwesomeApp() {
   return (


### PR DESCRIPTION
Correct way to export SafeAreaView is from default export.
`import SafeAreaView from 'react-native-safe-area-view';`